### PR TITLE
Fixed slash/backslash problem

### DIFF
--- a/Arduino_Fio/fp-lib-table
+++ b/Arduino_Fio/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Socket_Arduino_Fio)(type KiCad)(uri "$(KIPRJMOD)\\Socket_Arduino_Fio.pretty")(options "")(descr ""))
+  (lib (name Socket_Arduino_Fio)(type KiCad)(uri "$(KIPRJMOD)/Socket_Arduino_Fio.pretty")(options "")(descr ""))
 )

--- a/Arduino_Mega_R3/fp-lib-table
+++ b/Arduino_Mega_R3/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Socket_Arduino_Mega)(type KiCad)(uri "$(KIPRJMOD)\\Socket_Arduino_Mega.pretty")(options "")(descr ""))
+  (lib (name Socket_Arduino_Mega)(type KiCad)(uri "$(KIPRJMOD)/Socket_Arduino_Mega.pretty")(options "")(descr ""))
 )

--- a/Arduino_Micro/fp-lib-table
+++ b/Arduino_Micro/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Socket_Arduino_Micro)(type KiCad)(uri "$(KIPRJMOD)\\Socket_Arduino_Micro.pretty")(options "")(descr ""))
+  (lib (name Socket_Arduino_Micro)(type KiCad)(uri "$(KIPRJMOD)/Socket_Arduino_Micro.pretty")(options "")(descr ""))
 )

--- a/Arduino_Uno_R3/fp-lib-table
+++ b/Arduino_Uno_R3/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Socket_Arduino_Uno)(type KiCad)(uri "$(KIPRJMOD)\\Socket_Arduino_Uno.pretty")(options "")(descr ""))
+  (lib (name Socket_Arduino_Uno)(type KiCad)(uri "$(KIPRJMOD)/Socket_Arduino_Uno.pretty")(options "")(descr ""))
 )

--- a/BeagleBone-Black-Cape/fp-lib-table
+++ b/BeagleBone-Black-Cape/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Socket_BeagleBone_Black)(type KiCad)(uri "$(KIPRJMOD)\\Socket_BeagleBone_Black.pretty")(options "")(descr ""))
+  (lib (name Socket_BeagleBone_Black)(type KiCad)(uri "$(KIPRJMOD)/Socket_BeagleBone_Black.pretty")(options "")(descr ""))
 )


### PR DESCRIPTION
The five affected templates have backslashes in their footprint libraries paths. This doesn't work on Linux. 
I think Windows supports paths with slashes, so no problem here.