### PR TITLE
Fix wrong path for 3D model in raspberry_hat

### DIFF
--- a/raspberrypi_hat/raspberrypi_hat.kicad_pcb
+++ b/raspberrypi_hat/raspberrypi_hat.kicad_pcb
@@ -435,7 +435,7 @@
       (net 10 "Net-(J9-Pad2)"))
     (pad 8 smd rect (at 2.7 -1.905 180) (size 1.55 0.6) (layers F.Cu F.Paste F.Mask)
       (net 8 /P3V3))
-    (model ${KISYS3DMOD}/Package_SOIC.3dshapes/SOIC-8_3.9x4.9mm_P1.27mm.wrl
+    (model ${KISYS3DMOD}/Package_SO.3dshapes/SOIC-8_3.9x4.9mm_P1.27mm.wrl
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))


### PR DESCRIPTION
As in https://github.com/kicad/kicad-packages3d